### PR TITLE
Adding Cookbook content negotiation

### DIFF
--- a/.ebextensions/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.ebextensions/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -73,6 +73,20 @@ location / {
 	}
 }
 
+location /api/cookbook/recipe/0057-publishing-v2-and-v3/manifest.json {
+    resolver 8.8.8.8;
+    proxy_ssl_verify off;
+    proxy_ssl_server_name on;
+    proxy_set_header Host 'preview.iiif.io';
+    proxy_hide_header x-amz-id-2;
+    proxy_hide_header x-amz-request-id;
+    proxy_intercept_errors on;
+    proxy_pass https://preview.iiif.io:443/cookbook/0057-conneg/recipe/0057-publishing-v2-and-v3/manifest-$version.json;
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Cache-Control' 'public, no-transform, max-age=2419200';
+    add_header "X-UA-Compatible" "IE=Edge,chrome=1";
+}
+
 location ^~ /api/ {
 	# do json to json ld mime type conversion
 	# do presentation service

--- a/.ebextensions/nginx/conf.d/jsonldmap.conf
+++ b/.ebextensions/nginx/conf.d/jsonldmap.conf
@@ -6,3 +6,9 @@ map $uri $custom_content_type {
     default         "text/html";
     ~(.*\.xml)$  "application/rdf+xml";
 }
+
+map $http_accept $version {
+    default "v3";
+    "~http://iiif.io/api/presentation/2/context.json" "v2";
+    "~http://iiif.io/api/presentation/3/context.json" "v3";
+}

--- a/tests/TestHttps.py
+++ b/tests/TestHttps.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/bin/env python3
 import unittest
 import os
 import requests

--- a/tests/TestJsonLD.py
+++ b/tests/TestJsonLD.py
@@ -6,6 +6,7 @@ except ImportError:
     from urllib2 import urlopen
 from urllib import request
 import os
+import json
 
 class TestJsonLD(unittest.TestCase):
 	baseurl = ''
@@ -26,6 +27,25 @@ class TestJsonLD(unittest.TestCase):
 		response=opener.open(url)
 		mimetype=response.info().get('Content-type')
 		self.assertEqual(mimetype, 'application/ld+json', 'Mimetype should be jsonld if I support jsonld')
+
+	def test_cookbook_manifest(self):
+		url = '%s/%s' % (self.baseurl, 'api/cookbook/recipe/0057-publishing-v2-and-v3/manifest.json')
+		with urlopen(url) as urlPointer:
+			manifest = json.loads(urlPointer.read().decode())
+			self.assertEquals(manifest['@context'], 'http://iiif.io/api/presentation/3/context.json', 'Expected default retrieval of manifest to be version 3')
+
+		opener = request.build_opener()
+		opener.addheaders = [('Accept', "application/ld+json;profile=http://iiif.io/api/presentation/3/context.json")]
+		with opener.open(url) as urlPointer:
+			manifest = json.loads(urlPointer.read().decode())
+			self.assertEquals(manifest['@context'], 'http://iiif.io/api/presentation/3/context.json', 'Passing the 3 accept header should get version 3 but got version 2')
+
+		opener = request.build_opener()
+		opener.addheaders = [('Accept', "application/ld+json;profile=http://iiif.io/api/presentation/2/context.json")]
+		with opener.open(url) as urlPointer:
+			manifest = json.loads(urlPointer.read().decode())
+			self.assertEquals(manifest['@context'], 'http://iiif.io/api/presentation/2/context.json', 'Passing the 2 accept header should get version 2 manifest')
+                
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/TestRedirect.py
+++ b/tests/TestRedirect.py
@@ -43,12 +43,12 @@ class TestRedirect(unittest.TestCase):
 
     def test_image(self):
         url = '%s/%s' % (self.baseurl, 'api/image/')
-        dest = '%s/%s' % (self.desturl, 'api/image/2.1/')
+        dest = '%s/%s' % (self.desturl, 'api/image/3.0/')
         self.checkRedirect(url, dest)
 
     def test_presentation(self):
         url = '%s/%s' % (self.baseurl, 'api/presentation/index.html')
-        dest = '%s/%s' % (self.desturl, 'api/presentation/2.1/')
+        dest = '%s/%s' % (self.desturl, 'api/presentation/3.0/')
         self.checkRedirect(url, dest)
     def test_validator(self):
         url = '%s/%s' % (self.baseurl, 'api/presentation/validator')
@@ -81,7 +81,7 @@ class TestRedirect(unittest.TestCase):
         self.checkRedirect(url, dest)
     def test_api_redirect(self):
         url = '%s/%s' % (self.baseurl, 'api/image/')
-        dest = '%s/%s' % ('https://iiif.io', 'api/image/2.1/')
+        dest = '%s/%s' % ('https://iiif.io', 'api/image/3.0/')
         self.checkRedirect(url, dest, True)
 
     def test_editor_policy(self):


### PR DESCRIPTION
For:

https://github.com/IIIF/cookbook-recipes/pull/181

Now:

https://iiif.io/api/cookbook/recipe/0057-publishing-v2-and-v3/manifest.json

should resolve to either version 2 or 3 depending on which accept header is passed. 